### PR TITLE
refactored fixtures_teardown

### DIFF
--- a/src/functional_tests/tests_account_creation_login.py
+++ b/src/functional_tests/tests_account_creation_login.py
@@ -9,36 +9,9 @@ import selenium
 from django.contrib.auth.models import User
 from string import punctuation
 
-from .extra_utils.util_functions import create_permitted_user, generate_session_cookie, varnish_cache
+from .extra_utils.util_functions import create_permitted_user, generate_session_cookie, fixture_teardown
 
-# Fix for CASCADE TRUNCATE FK error
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
-# ---------------------------
+LiveServerTestCase._fixture_teardown = fixture_teardown
 
 # Account creation test
 

--- a/src/functional_tests/tests_add_org_form.py
+++ b/src/functional_tests/tests_add_org_form.py
@@ -9,41 +9,12 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 
 # Util functions
 
-from .extra_utils.util_functions import create_permitted_user, generate_session_cookie, varnish_cache
+from .extra_utils.util_functions import create_permitted_user, generate_session_cookie, varnish_cache, fixture_teardown
 
 # Models from pgweb codebase
 from .core.models import Organisation
 
-# Fix for CASCADE TRUNCATE FK error
-
-
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
-# ---------------------------
+LiveServerTestCase._fixture_teardown = fixture_teardown
 
 
 class OrgFormTests(LiveServerTestCase):

--- a/src/functional_tests/tests_bug_report_form.py
+++ b/src/functional_tests/tests_bug_report_form.py
@@ -6,37 +6,9 @@ from selenium import webdriver
 from django.test.testcases import call_command, connections
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
-from .extra_utils.util_functions import create_permitted_user, generate_session_cookie, varnish_cache
+from .extra_utils.util_functions import create_permitted_user, generate_session_cookie, varnish_cache, fixture_teardown
 
-
-# Fix for CASCADE TRUNCATE FK error
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
-# ---------------------------
+LiveServerTestCase._fixture_teardown = fixture_teardown
 
 
 class BugReportsForm(LiveServerTestCase):

--- a/src/functional_tests/tests_documentation_rendering.py
+++ b/src/functional_tests/tests_documentation_rendering.py
@@ -7,7 +7,7 @@ from selenium import webdriver
 from django.test.testcases import call_command, connections
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
-from .extra_utils.util_functions import varnish_cache
+from .extra_utils.util_functions import varnish_cache, fixture_teardown
 from .utils.download_docs import setup_documentation
 import concurrent.futures
 from copy import deepcopy
@@ -18,34 +18,7 @@ from bs4 import BeautifulSoup as Bsoup
 # Core Models
 from .core.models import Version
 
-
-# Fix for CASCADE TRUNCATE FK error
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
+LiveServerTestCase._fixture_teardown = fixture_teardown
 # ---------------------------
 
 

--- a/src/functional_tests/tests_events_page.py
+++ b/src/functional_tests/tests_events_page.py
@@ -12,7 +12,7 @@ from .core.models import Organisation, OrganisationType
 from .events.models import Event
 
 # Util functions
-from .extra_utils.util_functions import create_unauth_user, create_permitted_user, generate_session_cookie, varnish_cache
+from .extra_utils.util_functions import create_unauth_user, create_permitted_user, generate_session_cookie, varnish_cache, fixture_teardown
 
 
 markup_content = '''
@@ -81,34 +81,7 @@ github: [`Cveinnt/LetsMarkdown.com`](https://github.com/Cveinnt/LetsMarkdown.com
 
 '''
 
-
-# Fix for CASCADE TRUNCATE FK error
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
+LiveServerTestCase._fixture_teardown = fixture_teardown
 # ---------------------------
 
 

--- a/src/functional_tests/tests_homepage_links.py
+++ b/src/functional_tests/tests_homepage_links.py
@@ -8,7 +8,7 @@ from selenium import webdriver
 import requests
 from selenium.webdriver.firefox.service import Service
 from django.db import connection
-from .extra_utils.util_functions import varnish_cache
+from .extra_utils.util_functions import varnish_cache, fixture_teardown
 from bs4 import BeautifulSoup as BSoup
 from .extra_utils.crawler import CustomCrawler
 from .utils.download_docs import setup_documentation
@@ -19,33 +19,7 @@ from requests.packages.urllib3.util.retry import Retry
 from .extra_utils.crawler import CustomCrawler
 # Fix for CASCADE TRUNCATE FK error
 
-
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
+LiveServerTestCase._fixture_teardown = fixture_teardown
 # ---------------------------
 
 class CustomLinkTester(LiveServerTestCase):

--- a/src/functional_tests/tests_news_article_page.py
+++ b/src/functional_tests/tests_news_article_page.py
@@ -8,39 +8,12 @@ from selenium import webdriver
 from django.test.testcases import call_command, connections
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
-from .extra_utils.util_functions import create_permitted_user_with_org_email, generate_session_cookie, varnish_cache
+from .extra_utils.util_functions import create_permitted_user_with_org_email, generate_session_cookie, varnish_cache, fixture_teardown
 
 from .news.models import NewsArticle
 
-# Fix for CASCADE TRUNCATE FK error
 
-
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
+LiveServerTestCase._fixture_teardown = fixture_teardown
 # ---------------------------
 
 markup_content = '''

--- a/src/functional_tests/tests_products_form_page.py
+++ b/src/functional_tests/tests_products_form_page.py
@@ -7,7 +7,7 @@ from django.test.testcases import call_command, connections
 from django.contrib.staticfiles.testing import LiveServerTestCase
 import random
 
-from .extra_utils.util_functions import create_permitted_user_with_org_email, generate_session_cookie, varnish_cache
+from .extra_utils.util_functions import create_permitted_user_with_org_email, generate_session_cookie, varnish_cache, fixture_teardown
 from .downloads.models import Product
 
 
@@ -19,36 +19,9 @@ markup_content = '''<h1>Introducing Product X: Revolutionizing the Way You Work<
   <p>Product X seamlessly integrates with your existing tools and systems, ensuring a smooth transition and minimizing disruption. Whether you use popular productivity suites or specialized software, Product X effortlessly integrates to provide a unified and efficient work environment.</p>
   <p>Experience the benefits of automation, seamless integration with existing tools, and a user-friendly interface that simplifies complex tasks. Say goodbye to manual processes and embrace a new era of efficiency with Product X.</p>'''
 
-# Fix for CASCADE TRUNCATE FK error
 
-
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
 # ---------------------------
+LiveServerTestCase._fixture_teardown = fixture_teardown
 
 
 class ProductFormTests(LiveServerTestCase):

--- a/src/functional_tests/tests_prof_services_form.py
+++ b/src/functional_tests/tests_prof_services_form.py
@@ -7,40 +7,11 @@ from django.test.testcases import call_command, connections
 from django.contrib.staticfiles.testing import LiveServerTestCase
 import random
 
-from .extra_utils.util_functions import create_permitted_user_with_org_email, generate_session_cookie, varnish_cache
+from .extra_utils.util_functions import create_permitted_user_with_org_email, generate_session_cookie, varnish_cache, fixture_teardown
 from .profserv.models import ProfessionalService
 from .core.models import Organisation
 
-# Fix for CASCADE TRUNCATE FK error
-
-
-def _fixture_teardown(self):
-    # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
-    # when flushing only a subset of the apps
-    for db_name in self._databases_names(include_mirrors=False):
-        # Flush the database
-        inhibit_post_migrate = (
-            self.available_apps is not None
-            or (  # Inhibit the post_migrate signal when using serialized
-                # rollback to avoid trying to recreate the serialized data.
-                self.serialized_rollback
-                and hasattr(connections[db_name], "_test_serialized_contents")
-            )
-        )
-        call_command(
-            "flush",
-            verbosity=0,
-            interactive=False,
-            database=db_name,
-            reset_sequences=False,
-            # In the real TransactionTestCase this is conditionally set to False.
-            allow_cascade=True,
-            inhibit_post_migrate=inhibit_post_migrate,
-        )
-
-
-LiveServerTestCase._fixture_teardown = _fixture_teardown
-# ---------------------------
+LiveServerTestCase._fixture_teardown = fixture_teardown
 
 
 class ProductFormTests(LiveServerTestCase):


### PR DESCRIPTION
Solves #34 

 currently all functional tests are using exactly same _fixtures_teardown as internal module function. I would like to refactor it to extra_utils/util_functions.py as the teardown logic is independent of the testcase module.